### PR TITLE
Updated LICENSE Link in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Show some ❤️ by ⭐ the repository!
 ---
 
 ### License
-This project is licensed under the MIT License.
+This project is licensed under the [MIT LICENSE](./LICENSE).
 
 <div>
   <h2><img src="https://fonts.gstatic.com/s/e/notoemoji/latest/1f497/512.webp" width="35" height="35"> Contributors</h2>


### PR DESCRIPTION
The link of LICENSE in Readme file is updated, It'll look like this.

<img width="925" alt="image" src="https://github.com/user-attachments/assets/2ec9848c-f8d6-4949-8f13-4d38d91aad9f">
